### PR TITLE
Update GitHub Actions workflow to use latest versions of actions and .NET

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         name: Build & push Docker image
         with:
           image: kafka-retry-job
-          tags: 1.12.5, latest
+          tags: 1.12.6, latest
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Check out code
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '5.0'
+          dotnet-version: '7.0'
       - name: Setup Docker Daemon
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Run Unit & Integration Tests
-        run: dotnet test -c Release --no-restore --no-build
+        run: dotnet test -c Release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 
 variables:
-  VERSION: "1.12.5"
+  VERSION: "1.12.6"
   DOCKER_IMAGE_VERSION: $GITLAB_REGISTRY_HOST/$CI_PROJECT_PATH:$VERSION
   DOCKER_IMAGE_LATEST: $GITLAB_REGISTRY_HOST/$CI_PROJECT_PATH
 
@@ -19,7 +19,7 @@ stages:
 
 Test:
   stage: Test
-  image: mcr.microsoft.com/dotnet/sdk:5.0
+  image: mcr.microsoft.com/dotnet/sdk:7.0
   extends: .dind
   script:
     - dotnet test -c Release

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.12.6](https://github.com/github-changelog-generator/github-changelog-generator/tree/1.16.4) (2024-12)
+
+- Update .NET version from 5.0 to 7.0 in CI/CD pipelines
+- Fix GitHub Actions workflow to use .NET 7.0 and update action versions
+- Update GitLab CI to use .NET SDK 7.0
+
 ## [1.12.5](https://github.com/github-changelog-generator/github-changelog-generator/tree/1.16.4) (2024-03)
 
 - [\#46](https://github.com/Trendyol/kafka-retry-job/issues/46) Fixes the bug that keeps running the app alive when there is a lag, but no message in the topic partition


### PR DESCRIPTION
- Update GitHub Actions test workflow to use .NET 7.0
- Update GitHub Actions action versions (checkout@v4, setup-dotnet@v3, docker-buildx@v3)
- Update GitLab CI to use .NET SDK 7.0
- Bump version from 1.12.5 to 1.12.6 in publish.yml and .gitlab-ci.yml
- Add changelog entry for version 1.12.6